### PR TITLE
avoid here-document warning

### DIFF
--- a/SIS_Integration/bash_curl/sis_script.sh
+++ b/SIS_Integration/bash_curl/sis_script.sh
@@ -163,7 +163,8 @@ try:
   print res
 except Exception,e:
   print e,jstring
-END)
+END
+)
   #_log ${temp##*|}
   echo $myresult
 }


### PR DESCRIPTION
On Ubuntu 14.04 LTS this change just gets rid of the warning that occurs each time calling jasonval:
./sis_script.sh: line 178: warning: here-document at line 166 delimited by end-of-file (wanted `END')